### PR TITLE
BasicManagement: Update ID list state variables

### DIFF
--- a/src/librygel-core/filelist.am
+++ b/src/librygel-core/filelist.am
@@ -1,10 +1,10 @@
 LIBRYGEL_CORE_VAPI_SOURCE_FILES = \
 	rygel-connection-manager.vala \
 	rygel-basic-management.vala \
-	rygel-bm-test.vala \
-	rygel-bm-test-ping.vala \
-	rygel-bm-test-nslookup.vala \
-	rygel-bm-test-traceroute.vala \
+	rygel-basic-management-test.vala \
+	rygel-basic-management-test-ping.vala \
+	rygel-basic-management-test-nslookup.vala \
+	rygel-basic-management-test-traceroute.vala \
 	rygel-description-file.vala \
 	rygel-root-device.vala \
 	rygel-root-device-factory.vala \

--- a/src/librygel-core/rygel-basic-management-test-nslookup.vala
+++ b/src/librygel-core/rygel-basic-management-test-nslookup.vala
@@ -23,7 +23,7 @@
 
 using GLib;
 
-internal class Rygel.BMTestNSLookup : BMTest {
+internal class Rygel.BasicManagementTestNSLookup : BasicManagementTest {
     private const string HEADER =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
         "<bms:NSLookupResult " +
@@ -160,7 +160,7 @@ internal class Rygel.BMTestNSLookup : BMTest {
     public override string results_type { get { return "GetNSLookupResult"; } }
 
     public void init(string host_name, string? name_server, uint repetitions,
-                     uint32 interval_time_out) throws BMTestError {
+                     uint32 interval_time_out) throws BasicManagementTestError {
         command = { "nslookup" };
         generic_status = GenericStatus.ERROR_INTERNAL;
         results = {};
@@ -174,7 +174,8 @@ internal class Rygel.BMTestNSLookup : BMTest {
         command += ("-timeout=%u").printf (interval_time_out/1000);
 
         if (host_name == null || host_name.length < 1)
-            throw new BMTestError.INIT_FAILED ("Host name is required"); 
+            throw new BasicManagementTestError.INIT_FAILED
+                                                ("Host name is required");
         command += host_name;
 
         if (name_server != null && name_server.length > 0)
@@ -199,7 +200,7 @@ internal class Rygel.BMTestNSLookup : BMTest {
     }
 
     protected override void finish_iteration () {
-        switch (execution_state) {
+        switch (this.execState) {
             case ExecutionState.SPAWN_FAILED:
                 generic_status = GenericStatus.ERROR_INTERNAL;
                 additional_info = "Failed spawn nslookup";
@@ -220,7 +221,7 @@ internal class Rygel.BMTestNSLookup : BMTest {
         if (line.contains ("couldn't get address for")) {
             generic_status = GenericStatus.ERROR_DNS_SERVER_NOT_RESOLVED;
             result.status = ResultStatus.ERROR_DNS_SERVER_NOT_AVAILABLE;
-            execution_state = ExecutionState.COMPLETED;
+            this.execState = ExecutionState.COMPLETED;
         }
 
         /* there has to be a nicer way to do this... */
@@ -259,7 +260,7 @@ internal class Rygel.BMTestNSLookup : BMTest {
         } else if (line.contains ("couldn't get address for")) {
             generic_status = GenericStatus.ERROR_DNS_SERVER_NOT_RESOLVED;
             result.status = ResultStatus.ERROR_DNS_SERVER_NOT_AVAILABLE;
-            execution_state = ExecutionState.COMPLETED;
+            this.execState = ExecutionState.COMPLETED;
         } else if (line.contains ("no servers could be reached")) {
             result.status = ResultStatus.ERROR_DNS_SERVER_NOT_AVAILABLE;
         }
@@ -290,7 +291,7 @@ internal class Rygel.BMTestNSLookup : BMTest {
 
     private static int main(string[] args) {
         MainLoop loop = new MainLoop();
-        BMTestNSLookup nslookup = new BMTestNSLookup ();
+        BasicManagementTestNSLookup nslookup = new BasicManagementTestNSLookup ();
 
         if (args.length < 2) {
             print ("Usage: %s <hostname> [<nameserver> [<repetitions> [<timeout>]]]\n", args[0]);
@@ -302,7 +303,7 @@ internal class Rygel.BMTestNSLookup : BMTest {
                            args.length > 2 ? args[2] : null,
                            args.length > 3 ? int.parse (args[3]): 0,
                            args.length > 4 ? int.parse (args[4]) : 0);
-        } catch (BMTestError e) {
+        } catch (BasicManagementTestError e) {
             warning ("Incorrect parameters");
         }
 

--- a/src/librygel-core/rygel-basic-management-test-ping.vala
+++ b/src/librygel-core/rygel-basic-management-test-ping.vala
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2008 OpenedHand Ltd.
- * Copyright (C) 2008 Zeeshan Ali <zeenix@gmail.com>.
  * Copyright (C) 2013 Intel Corporation.
  *
- * Author: Jorn Baayen <jorn@openedhand.com>
- *         Zeeshan Ali <zeenix@gmail.com>
+ * Author: Christophe Guiraud,
+ *         Jussi Kukkonen
  *
  * This file is part of Rygel.
  *
@@ -25,8 +23,8 @@
 
 using GLib;
 
-// Helper class for BMTestPing.
-internal class Rygel.BMTestPing : BMTest {
+// Helper class for BasicManagementTestPing.
+internal class Rygel.BasicManagementTestPing : BasicManagementTest {
 
     private string host;
     private uint repeat_count;

--- a/src/librygel-core/rygel-basic-management-test-traceroute.vala
+++ b/src/librygel-core/rygel-basic-management-test-traceroute.vala
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2008 OpenedHand Ltd.
- * Copyright (C) 2008 Zeeshan Ali <zeenix@gmail.com>.
  * Copyright (C) 2013 Intel Corporation.
  *
- * Author: Jorn Baayen <jorn@openedhand.com>
- *         Zeeshan Ali <zeenix@gmail.com>
+ * Author: Christophe Guiraud,
+ *         Jussi Kukkonen
  *
  * This file is part of Rygel.
  *
@@ -25,8 +23,8 @@
 
 using GLib;
 
-// Helper class for BMTestTraceroute.
-internal class Rygel.BMTestTraceroute : BMTest {
+// Helper class for BasicManagementTestTraceroute.
+internal class Rygel.BasicManagementTestTraceroute : BasicManagementTest {
 
     private string host;
     private uint32 wait_time_out;


### PR DESCRIPTION
- Use HashMap for the the Test ID/Test active ID list.
- Update the Test ID/Test active ID list state upon the reception of test state change notification.
- Cosmetic: use long filename for files and classes. e.g: rygel-bm-test.vala -> rygel-basic-management-test.vala
- Cosmetic: copyright headers cleanup.
- Compute Test ID/Test active ID HashMap on fly when they have to be provided to gupnp layer.
- Initialize device status with current time and OK status.

Signed-off-by: Christophe Guiraud christophe.guiraud@intel.com
