### PR TITLE
BasicManagement: Update ID list state variables

### DIFF
--- a/src/librygel-core/filelist.am
+++ b/src/librygel-core/filelist.am
@@ -1,10 +1,10 @@
 LIBRYGEL_CORE_VAPI_SOURCE_FILES = \
 	rygel-connection-manager.vala \
 	rygel-basic-management.vala \
-	rygel-bm-test.vala \
-	rygel-bm-test-ping.vala \
-	rygel-bm-test-nslookup.vala \
-	rygel-bm-test-traceroute.vala \
+	rygel-basic-management-test.vala \
+	rygel-basic-management-test-ping.vala \
+	rygel-basic-management-test-nslookup.vala \
+	rygel-basic-management-test-traceroute.vala \
 	rygel-description-file.vala \
 	rygel-root-device.vala \
 	rygel-root-device-factory.vala \

--- a/src/librygel-core/rygel-basic-management-test-nslookup.vala
+++ b/src/librygel-core/rygel-basic-management-test-nslookup.vala
@@ -23,7 +23,7 @@
 
 using GLib;
 
-internal class Rygel.BMTestNSLookup : BMTest {
+internal class Rygel.BasicManagementTestNSLookup : BasicManagementTest {
     private const string HEADER =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
         "<bms:NSLookupResult " +
@@ -160,7 +160,7 @@ internal class Rygel.BMTestNSLookup : BMTest {
     public override string results_type { get { return "GetNSLookupResult"; } }
 
     public void init(string host_name, string? name_server, uint repetitions,
-                     uint32 interval_time_out) throws BMTestError {
+                     uint32 interval_time_out) throws BasicManagementTestError {
         command = { "nslookup" };
         generic_status = GenericStatus.ERROR_INTERNAL;
         results = {};
@@ -174,7 +174,8 @@ internal class Rygel.BMTestNSLookup : BMTest {
         command += ("-timeout=%u").printf (interval_time_out/1000);
 
         if (host_name == null || host_name.length < 1)
-            throw new BMTestError.INIT_FAILED ("Host name is required"); 
+            throw new BasicManagementTestError.INIT_FAILED
+                                                ("Host name is required");
         command += host_name;
 
         if (name_server != null && name_server.length > 0)
@@ -199,7 +200,7 @@ internal class Rygel.BMTestNSLookup : BMTest {
     }
 
     protected override void finish_iteration () {
-        switch (execution_state) {
+        switch (this.execution_state) {
             case ExecutionState.SPAWN_FAILED:
                 generic_status = GenericStatus.ERROR_INTERNAL;
                 additional_info = "Failed spawn nslookup";
@@ -220,7 +221,7 @@ internal class Rygel.BMTestNSLookup : BMTest {
         if (line.contains ("couldn't get address for")) {
             generic_status = GenericStatus.ERROR_DNS_SERVER_NOT_RESOLVED;
             result.status = ResultStatus.ERROR_DNS_SERVER_NOT_AVAILABLE;
-            execution_state = ExecutionState.COMPLETED;
+            this.execution_state = ExecutionState.COMPLETED;
         }
 
         /* there has to be a nicer way to do this... */
@@ -259,7 +260,7 @@ internal class Rygel.BMTestNSLookup : BMTest {
         } else if (line.contains ("couldn't get address for")) {
             generic_status = GenericStatus.ERROR_DNS_SERVER_NOT_RESOLVED;
             result.status = ResultStatus.ERROR_DNS_SERVER_NOT_AVAILABLE;
-            execution_state = ExecutionState.COMPLETED;
+            this.execution_state = ExecutionState.COMPLETED;
         } else if (line.contains ("no servers could be reached")) {
             result.status = ResultStatus.ERROR_DNS_SERVER_NOT_AVAILABLE;
         }
@@ -290,7 +291,7 @@ internal class Rygel.BMTestNSLookup : BMTest {
 
     private static int main(string[] args) {
         MainLoop loop = new MainLoop();
-        BMTestNSLookup nslookup = new BMTestNSLookup ();
+        BasicManagementTestNSLookup nslookup = new BasicManagementTestNSLookup ();
 
         if (args.length < 2) {
             print ("Usage: %s <hostname> [<nameserver> [<repetitions> [<timeout>]]]\n", args[0]);
@@ -302,7 +303,7 @@ internal class Rygel.BMTestNSLookup : BMTest {
                            args.length > 2 ? args[2] : null,
                            args.length > 3 ? int.parse (args[3]): 0,
                            args.length > 4 ? int.parse (args[4]) : 0);
-        } catch (BMTestError e) {
+        } catch (BasicManagementTestError e) {
             warning ("Incorrect parameters");
         }
 

--- a/src/librygel-core/rygel-basic-management-test-ping.vala
+++ b/src/librygel-core/rygel-basic-management-test-ping.vala
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2008 OpenedHand Ltd.
- * Copyright (C) 2008 Zeeshan Ali <zeenix@gmail.com>.
  * Copyright (C) 2013 Intel Corporation.
  *
- * Author: Jorn Baayen <jorn@openedhand.com>
- *         Zeeshan Ali <zeenix@gmail.com>
+ * Author: Christophe Guiraud,
+ *         Jussi Kukkonen
  *
  * This file is part of Rygel.
  *
@@ -25,8 +23,8 @@
 
 using GLib;
 
-// Helper class for BMTestPing.
-internal class Rygel.BMTestPing : BMTest {
+// Helper class for BasicManagementTestPing.
+internal class Rygel.BasicManagementTestPing : BasicManagementTest {
 
     private string host;
     private uint repeat_count;

--- a/src/librygel-core/rygel-basic-management-test-traceroute.vala
+++ b/src/librygel-core/rygel-basic-management-test-traceroute.vala
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2008 OpenedHand Ltd.
- * Copyright (C) 2008 Zeeshan Ali <zeenix@gmail.com>.
  * Copyright (C) 2013 Intel Corporation.
  *
- * Author: Jorn Baayen <jorn@openedhand.com>
- *         Zeeshan Ali <zeenix@gmail.com>
+ * Author: Christophe Guiraud,
+ *         Jussi Kukkonen
  *
  * This file is part of Rygel.
  *
@@ -25,8 +23,8 @@
 
 using GLib;
 
-// Helper class for BMTestTraceroute.
-internal class Rygel.BMTestTraceroute : BMTest {
+// Helper class for BasicManagementTestTraceroute.
+internal class Rygel.BasicManagementTestTraceroute : BasicManagementTest {
 
     private string host;
     private uint32 wait_time_out;

--- a/src/librygel-core/rygel-basic-management-test.vala
+++ b/src/librygel-core/rygel-basic-management-test.vala
@@ -2,7 +2,7 @@
  * Copyright (C) 2013 Intel Corporation.
  *
  * Author: Christophe Guiraud,
- *         Jussi Kukkonen 
+ *         Jussi Kukkonen
  *
  * This file is part of Rygel.
  *
@@ -24,12 +24,12 @@
 using GLib;
 
 
-internal errordomain Rygel.BMTestError {
+internal errordomain Rygel.BasicManagementTestError {
     NOT_POSSIBLE,
     INIT_FAILED,
 }
 
-internal abstract class Rygel.BMTest : Object {
+internal abstract class Rygel.BasicManagementTest : Object {
     public enum ExecutionState {
         REQUESTED,
         IN_PROGRESS,
@@ -55,7 +55,9 @@ internal abstract class Rygel.BMTest : Object {
             }
         }
     }
+
     public ExecutionState execution_state;
+    
     public string id;
 
     /* properties implementations need to provide */
@@ -88,10 +90,10 @@ internal abstract class Rygel.BMTest : Object {
     }
     protected virtual void finish_iteration () {
         iteration++;
-        if (execution_state != ExecutionState.IN_PROGRESS) {
+        if (this.execution_state != ExecutionState.IN_PROGRESS) {
             async_callback ();
         } else if (iteration >= repetitions) {
-            execution_state = ExecutionState.COMPLETED;
+            this.execution_state = ExecutionState.COMPLETED;
             async_callback ();
         } else {
             run_iteration ();
@@ -131,7 +133,7 @@ internal abstract class Rygel.BMTest : Object {
                                    err_watch);
         } catch (SpawnError e) {
             /* Let the async function yeild, then error out */
-            execution_state = ExecutionState.SPAWN_FAILED;
+            this.execution_state = ExecutionState.SPAWN_FAILED;
             Idle.add ((SourceFunc)finish_iteration);
         }
     }
@@ -183,16 +185,17 @@ internal abstract class Rygel.BMTest : Object {
     }
 
 
-    public BMTest() {
+    public BasicManagementTest() {
         this.execution_state = ExecutionState.REQUESTED;
         this.id = null;
     }
 
-    public async virtual void execute () throws BMTestError {
-        if (execution_state != ExecutionState.REQUESTED)
-            throw new BMTestError.NOT_POSSIBLE ("Already executing or executed");
+    public async virtual void execute () throws BasicManagementTestError {
+        if (this.execution_state != ExecutionState.REQUESTED)
+            throw new BasicManagementTestError.NOT_POSSIBLE
+                                                ("Already executing or executed");
 
-        execution_state = ExecutionState.IN_PROGRESS;
+        this.execution_state = ExecutionState.IN_PROGRESS;
         iteration = 0;
         async_callback = execute.callback;
 
@@ -202,12 +205,12 @@ internal abstract class Rygel.BMTest : Object {
         return;
     }
 
-    public void cancel () throws BMTestError {
-        if (execution_state != ExecutionState.IN_PROGRESS)
-            throw new BMTestError.NOT_POSSIBLE ("Not executing"); 
+    public void cancel () throws BasicManagementTestError {
+        if (this.execution_state != ExecutionState.IN_PROGRESS)
+            throw new BasicManagementTestError.NOT_POSSIBLE ("Not executing");
 
         Posix.killpg (child_pid, Posix.SIGTERM);
 
-        execution_state = ExecutionState.CANCELED;
+        this.execution_state = ExecutionState.CANCELED;
     }
 }

--- a/src/librygel-core/rygel-basic-management.vala
+++ b/src/librygel-core/rygel-basic-management.vala
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2008 OpenedHand Ltd.
- * Copyright (C) 2008 Zeeshan Ali <zeenix@gmail.com>.
  * Copyright (C) 2013 Intel Corporation.
  *
- * Author: Jorn Baayen <jorn@openedhand.com>
- *         Zeeshan Ali <zeenix@gmail.com>
+ * Author: Christophe Guiraud,
+ *         Jussi Kukkonen
  *
  * This file is part of Rygel.
  *
@@ -36,24 +34,23 @@ public class Rygel.BasicManagement : Service {
                         "urn:schemas-upnp-org:service:BasicManagement:2";
     public const string DESCRIPTION_PATH = "xml/BasicManagement2.xml";
 
-    private LinkedList<BMTest> tests_list;
-    private LinkedList<BMTest> active_tests_list;
+    private HashMap<string, BasicManagementTest> tests_map;
+    private HashMap<string, BasicManagementTest> active_tests_map;
 
     private static uint current_id = 0;
 
     protected string device_status;
-    protected string test_ids;
-    protected string active_test_ids;
 
     public override void constructed () {
         base.constructed ();
 
-        this.tests_list = new LinkedList<BMTest> ();
-        this.active_tests_list = new LinkedList<BMTest> ();
+        this.tests_map = new HashMap<string, BasicManagementTest> ();
+        this.active_tests_map = new HashMap<string, BasicManagementTest> ();
 
-        this.device_status   = "OK,2009-06-15T12:00:00,Details";
-        this.test_ids        = "";
-        this.active_test_ids = "";
+        var now = TimeVal ();
+        now.tv_usec = 0;
+
+        this.device_status = "OK," + now.to_iso8601 ();
 
         this.query_variable["DeviceStatus"].connect
                                         (this.query_device_status_cb);
@@ -86,71 +83,129 @@ public class Rygel.BasicManagement : Service {
                                         (this.cancel_test_cb);
     }
 
-    private void add_test_and_return_action (BMTest bm_test, ServiceAction action) {
+    private string create_test_ids_list (bool active) {
+        string test_ids_list = "";
+        HashMap<string, BasicManagementTest> test_map;
+
+        if (active) {
+            test_map = this.active_tests_map;
+        } else {
+            test_map = this.tests_map;
+        }
+
+        foreach (string key in test_map.keys) {
+            if (test_ids_list == "") {
+                test_ids_list = key;
+            } else {
+                test_ids_list += "," + key;
+            }
+        }
+
+        return test_ids_list;
+    }
+
+    private void update_test_ids_lists (BasicManagementTest bm_test) {
+        BasicManagementTest.ExecutionState execution_state = bm_test.execution_state;
+
+        if ((execution_state == BasicManagementTest.ExecutionState.REQUESTED) ||
+            (execution_state == BasicManagementTest.ExecutionState.REQUESTED)) {
+            this.tests_map.set (bm_test.id, bm_test);
+            this.notify ("TestIDs", typeof (string),
+                         create_test_ids_list (false));
+
+            this.active_tests_map.set (bm_test.id, bm_test);
+            this.notify ("ActiveTestIDs", typeof (string),
+                         create_test_ids_list (true));
+        } else if ((execution_state == BasicManagementTest.ExecutionState.CANCELED) ||
+                   (execution_state == BasicManagementTest.ExecutionState.COMPLETED) ||
+                   (execution_state == BasicManagementTest.ExecutionState.SPAWN_FAILED)) {
+            this.active_tests_map.unset (bm_test.id);
+            this.notify ("ActiveTestIDs", typeof (string),
+                         create_test_ids_list (true));
+        }
+    }
+
+    private void add_test_and_return_action (BasicManagementTest bm_test,
+                                             ServiceAction action) {
         current_id++;
+
         bm_test.id = current_id.to_string ();
 
-        this.tests_list.add (bm_test);
-
-        this.test_ids = "";
-        foreach (BMTest test in this.tests_list) {
-             if (this.test_ids == "") {
-                 this.test_ids = test.id;
-             } else {
-                 this.test_ids += "," + test.id;
-             }
-        }
+        update_test_ids_lists (bm_test);
 
         /* TODO: decide if test should really execute now */
 
         bm_test.execute.begin ((obj,res) => {
             try {
                 bm_test.execute.end (res);
-            } catch (BMTestError e) {
+            } catch (BasicManagementTestError e) {
                 /* already executing */
             }
-            /* TODO Test is finished, now remove test from active test list */
+
+            update_test_ids_lists (bm_test);
         });
 
         action.set ("TestID",
                         typeof (string),
                         bm_test.id);
+
         action.return ();
     }
 
+/*
+    /// TODO: NOT USED YET
+    private void remove_test (BasicManagementTest bm_test) {
+        bm_test
+        if (this.tests_map.unset (bm_test.id) == true) {
+            this.notify ("TestIDs", typeof (string),
+                         create_test_ids_list (false));
+        }
+
+        if (this.active_tests_map.unset (bm_test.id) == true) {
+            this.cancel();
+
+            this.notify ("ActiveTestIDs", typeof (string),
+                         create_test_ids_list (true));
+        }
+    }
+*/
+
     // Error out if 'TestID' is wrong
-    private bool check_test_id (ServiceAction action, out BMTest bm_test) {
+    private bool ensure_test_exists (ServiceAction action,
+                                     out BasicManagementTest bm_test) {
 
         string test_id;
 
         action.get ("TestID", typeof (string), out test_id);
 
-        bm_test = null;
-
-        foreach (BMTest test in this.tests_list) {
-             if (test.id == test_id) {
-                 bm_test = test;
-
-                 break;
-             }
-        }
+        bm_test = this.tests_map[test_id];
 
         if (bm_test == null) {
-            // No test with the specified TestID was found
+            /// No test with the specified TestID was found
             action.return_error (706, _("No Such Test"));
 
             return false;
-        } else if ((action.get_name() != "CancelTest") &&
-                   (action.get_name() != "GetTestInfo") &&
-                   (bm_test.results_type != action.get_name())) {
-            // TestID is valid but refers to the wrong test type
+        } else if ((bm_test.results_type != action.get_name()) &&
+                   ((action.get_name() == "GetPingResult") ||
+                    (action.get_name() == "GetNSLookupResult") ||
+                    (action.get_name() == "GetTracerouteResult"))) {
+            /// TestID is valid but refers to the wrong test type
             action.return_error (707, _("Wrong Test Type"));
 
             return false;
-        } else if ((action.get_name() != "GetTestInfo") &&
-                   (bm_test.execution_state != BMTest.ExecutionState.COMPLETED)) {
-            // TestID is valid but the test Results are not available
+        } else if ((bm_test.execution_state != BasicManagementTest.ExecutionState.COMPLETED) &&
+                   ((action.get_name() == "GetPingResult") ||
+                    (action.get_name() == "GetNSLookupResult") ||
+                    (action.get_name() == "GetTracerouteResult"))) {
+            /// TestID is valid but the test Results are not available
             action.return_error (708, _("Invalid Test State"));
+
+            return false;
+        } else if ((action.get_name() == "CancelTest") &&
+                   ((bm_test.execution_state == BasicManagementTest.ExecutionState.CANCELED) ||
+                    (bm_test.execution_state == BasicManagementTest.ExecutionState.COMPLETED))) {
+            /// TestID is valid but the test can't be canceled
+            action.return_error (709, _("State Precludes Cancel"));
 
             return false;
         }
@@ -169,14 +224,14 @@ public class Rygel.BasicManagement : Service {
                                     string    var,
                                     ref Value val) {
         val.init (typeof (string));
-        val.set_string (test_ids);
+        val.set_string (create_test_ids_list (false));
     }
 
     private void query_active_test_ids_cb (Service   cm,
                                            string    var,
                                            ref Value val) {
         val.init (typeof (string));
-        val.set_string (active_test_ids);
+        val.set_string (create_test_ids_list (true));
     }
 
     private void get_device_status_cb (Service             cm,
@@ -222,7 +277,7 @@ public class Rygel.BasicManagement : Service {
                         typeof (uint),
                         out dscp);
 
-        BMTestPing ping = new BMTestPing();
+        var ping = new BasicManagementTestPing();
         if (!ping.init (host, repeat_count, interval_time_out,
                         data_block_size, dscp)) {
             action.return_error (402, _("Invalid argument"));
@@ -230,8 +285,7 @@ public class Rygel.BasicManagement : Service {
             return;
         }
 
-        // test_id to be added to TestIDs and ActiveTestID
-        this.add_test_and_return_action (ping as BMTest, action);
+        this.add_test_and_return_action (ping as BasicManagementTest, action);
     }
 
     private void ping_result_cb (Service             cm,
@@ -242,9 +296,9 @@ public class Rygel.BasicManagement : Service {
             return;
         }
 
-        BMTest bm_test;
+        BasicManagementTest bm_test;
 
-        if (!this.check_test_id (action, out bm_test)) {
+        if (!this.ensure_test_exists (action, out bm_test)) {
             return;
         }
 
@@ -252,7 +306,8 @@ public class Rygel.BasicManagement : Service {
         uint success_count, failure_count;
         uint32 average_response_time, min_response_time, max_response_time;
 
-        (bm_test as BMTestPing).get_results (out status, out additional_info,
+        (bm_test as BasicManagementTestPing).get_results (out status,
+                                             out additional_info,
                                              out success_count,
                                              out failure_count,
                                              out average_response_time,
@@ -310,13 +365,14 @@ public class Rygel.BasicManagement : Service {
                         typeof (uint32),
                         out interval_time_out);
 
-        BMTestNSLookup nslookup = new BMTestNSLookup();
+        var nslookup = new BasicManagementTestNSLookup();
         try {
             nslookup.init (hostname, dns_server,
                            repeat_count, interval_time_out);
 
-            this.add_test_and_return_action (nslookup as BMTest, action);
-        } catch (BMTestError e) {
+            this.add_test_and_return_action (nslookup as BasicManagementTest,
+                                             action);
+        } catch (BasicManagementTestError e) {
             action.return_error (402, _("Invalid argument"));
         }
     }
@@ -329,16 +385,16 @@ public class Rygel.BasicManagement : Service {
             return;
         }
 
-        BMTest bm_test;
+        BasicManagementTest bm_test;
 
-        if (!this.check_test_id (action, out bm_test)) {
+        if (!this.ensure_test_exists (action, out bm_test)) {
             return;
         }
 
         string status, additional_info, result;
         uint success_count;
 
-        (bm_test as BMTestNSLookup).get_results (out status,
+        (bm_test as BasicManagementTestNSLookup).get_results (out status,
                                                  out additional_info,
                                                  out success_count,
                                                  out result);
@@ -387,7 +443,7 @@ public class Rygel.BasicManagement : Service {
                         typeof (uint),
                         out dscp);
 
-        BMTestTraceroute traceroute = new BMTestTraceroute();
+        var traceroute = new BasicManagementTestTraceroute();
         if (!traceroute.init (host, wait_time_out, data_block_size,
                               max_hop_count, dscp)) {
             action.return_error (402, _("Invalid argument"));
@@ -395,7 +451,8 @@ public class Rygel.BasicManagement : Service {
             return;
         }
 
-        this.add_test_and_return_action (traceroute as BMTest, action);
+        this.add_test_and_return_action (traceroute as BasicManagementTest,
+                                         action);
     }
 
     private void traceroute_result_cb (Service             cm,
@@ -406,16 +463,16 @@ public class Rygel.BasicManagement : Service {
             return;
         }
 
-        BMTest bm_test;
+        BasicManagementTest bm_test;
 
-        if (!this.check_test_id (action, out bm_test)) {
+        if (!this.ensure_test_exists (action, out bm_test)) {
             return;
         }
 
         string status, additional_info, hop_hosts;
         uint32 response_time;
 
-        (bm_test as BMTestTraceroute).get_results (out status,
+        (bm_test as BasicManagementTestTraceroute).get_results (out status,
                                                    out additional_info,
                                                    out response_time,
                                                    out hop_hosts);
@@ -446,7 +503,7 @@ public class Rygel.BasicManagement : Service {
 
         action.set ("TestIDs",
                         typeof (string),
-                        this.test_ids);
+                        create_test_ids_list (false));
 
         action.return ();
     }
@@ -461,7 +518,7 @@ public class Rygel.BasicManagement : Service {
 
         action.set ("TestIDs",
                         typeof (string),
-                        this.active_test_ids);
+                        create_test_ids_list (true));
 
         action.return ();
     }
@@ -474,9 +531,9 @@ public class Rygel.BasicManagement : Service {
             return;
         }
 
-        BMTest bm_test;
+        BasicManagementTest bm_test;
 
-        if (!this.check_test_id (action, out bm_test)) {
+        if (!this.ensure_test_exists (action, out bm_test)) {
             return;
         }
 
@@ -498,15 +555,15 @@ public class Rygel.BasicManagement : Service {
             return;
         }
 
-        BMTest bm_test;
+        BasicManagementTest bm_test;
 
-        if (!this.check_test_id (action, out bm_test)) {
+        if (!this.ensure_test_exists (action, out bm_test)) {
             return;
         }
 
         try {
             bm_test.cancel();
-        } catch (BMTestError e) {
+        } catch (BasicManagementTestError e) {
             warning ("Canceled test was not running\n");
         }
 


### PR DESCRIPTION
applied jku's review feedback: 
- removed test state notification as it is not necessary to update the test ids list.
- use var when creating a test class instance.

---
- Use HashMap for the the Test ID/Test active ID list.
- Update the Test ID/Test active ID list state when a test is added, completed or removed.
- Cosmetic: use long filename for files and classes. e.g: rygel-bm-test.vala -> rygel-basic-management-test.vala
- Cosmetic: copyright headers cleanup.
- Compute Test ID/Test active ID HashMap on fly when they have to be provided to gupnp layer.
- Initialize device status with current time and OK status.

Signed-off-by: Christophe Guiraud christophe.guiraud@intel.com
