### PR TITLE
BasicManagement: Add tests history limit

### DIFF
--- a/src/librygel-core/rygel-basic-management-test.vala
+++ b/src/librygel-core/rygel-basic-management-test.vala
@@ -209,6 +209,11 @@ internal abstract class Rygel.BasicManagementTest : Object {
         return true;
     }
 
+    public bool is_active () {
+        return this.execution_state == ExecutionState.REQUESTED ||
+               this.execution_state == ExecutionState.IN_PROGRESS;
+    }
+
     public async virtual void execute () throws BasicManagementTestError {
         if (this.execution_state != ExecutionState.REQUESTED)
             throw new BasicManagementTestError.NOT_POSSIBLE


### PR DESCRIPTION
This is an evolution of PR #12. I didn't really have anything against that patch but I felt it could be possible to achieve the same with less work and less state variables.

It's certainly less code, and at least in my eyes it seems simpler... What do you think?
